### PR TITLE
[FIX] Fix bug in plugins/gen_data_st.py

### DIFF
--- a/plugins/gen_data_st.py
+++ b/plugins/gen_data_st.py
@@ -14,7 +14,7 @@ import sys
 import time
 os.chdir(sys.path[0][:-8])
 
-from common import success_print
+from common import success_print, error_print
 from common import error_helper
 from common import settings
 from common import CounterLock


### PR DESCRIPTION
为 rtst 模式的知识库生成词向量时，输出报错信息 "txt 目录没有数据" 的 error_print 函数没有引入。

![Wenda-GenRtst-ImportBug.png](https://s2.loli.net/2023/05/25/4Kxp7vDXVQ6uo3C.png)
