### PR TITLE
增强知识库前端友好行为, 点击知识库来源标签跳转到用户按照给定格式存储在文件名中的超链接

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+test
 model
 vc
 txt2

--- a/autos/0-zsk.js
+++ b/autos/0-zsk.js
@@ -3,24 +3,59 @@
 // @namespace    http://tampermonkey.net/
 // @version      0.1
 // @description  利用知识库回答问题
-// @author       lyyyyy
+// @author       lyyyyy,pengber
 // @match        http://127.0.0.1:17860/
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=0.1
 // @run-at document-idle
 // @grant        none
 // ==/UserScript==
-get_title_form_md = (s) => {
-    console.log(s)
+//辅助函数
+//在pdf和txt文件名中存储链接,形如title&http~!!www.baidu.com&.pdf格式,~是因为windows文件名不能有:,!是因为linux文件名不能有/
+//返回http://www.baidu.com
+get_link_form_name= (s) => {
     try {
-        return s.match('\\[(.+)\\]')[1]
+        if(s.includes("&")) {
+            replace_symbol = "!"        //因为linux文件名不能有/,而连接有/, 所以需要在文件名存储的时候把/替换成!,在前端显示的时候替换回来
+            raw_title = s.match('\\[(.+)\\]')[1]
+            raw_link = raw_title.match('\\&(.+)\\&') == null ? null: raw_title.match('\\&(.+)\\&')[1]
+            real_link = raw_link.replace(/!/g,"/").replace(/~/g,":")
+            return real_link
+        }else{
+            return null
+        }
     } catch {
         return s
     }
 }
-get_url_form_md = (s) => {
-    console.log(s)
+//返回文件名
+//title.txt格式和title&link&.txt格式, 都返回title.txt
+get_title_form_md = (s) => {
     try {
-        return s.match('\\((.+)\\)')[1]
+        
+        if(!s.includes("&")){
+            return s.match('\\[(.+)\\]')[1]
+        }else{
+            str_list = s.match('\\[(.+)\\]')[1].split("&")
+            title = str_list[0] + str_list[str_list.length-1]
+            return title
+        }
+    } catch {
+        return s
+    }
+}
+//
+//返回路径
+//如果形如title&http~!!www.baidu.com&.pdf,则返回链接使得前端点击可以跳转
+//如果形如title.pdf, 则返回/txt/title.pdf
+get_url_form_md = (s) => {
+    try {
+        link = get_link_form_name(s)
+        if(link == null) {
+            return s.match('\\((.+)\\)')[1]
+        }else{
+            return link
+        }
+        
     } catch {
         return s
     }


### PR DESCRIPTION
现在: 现有的知识库是形成title.txt文件放入txt, 点击知识库问答后可以跳转到服务器资源例如localhost/txt/title.xt查看知识库内容.

需求: 知识的来源大部分可能是网页形式, 而进行了一定的清洗和抽取形成了title.txt的content, 但是有时候我们还知道知识来源于的网页还有哪些内容, 例如这个[issue](https://github.com/wenda-LLM/wenda/issues/147), 或者源网页可读性更好

增强:

1. 兼容原来点击知识标签跳转到本地资源的行为

2. 如果用户使用场景更多的是点击知识来源标签查看源网页而不是本地知识库, 则可以在形成知识库时将文件名处理成`title&link&.txt`, 其中, `link`是超链接, 并且将超链接中的`:`替换成`~`, `/`替换成`!`.
   **例如: `百度.txt`, 则闻达知识来源标签为`百度.txt`, 点击标签后会跳转到`localhost/txt/百度.txt`.**

   **例如: `百度&http~!!www.baidu.com&.txt`, 则闻达知识来源标签为`百度.txt`, 点击标签后会跳转到`http://www.baidu.com`.**

3. 用`~`替换`:`是因为windows文件名不支持`:`, 用`!`替换`/`是因为linux文件名不支持`/`.

4.  在用户按照给定格式组织知识库的文件名后, 再次点击知识来源标签会跳转到网页而不是本地知识库.