### PR TITLE
修复无法正常检测使用系统Python解释器的BUG。

### DIFF
--- a/environment.bat
+++ b/environment.bat
@@ -23,10 +23,7 @@ echo 检测到RWKV-Runner集成环境
 set "PATH=%WINPYDIR%\;%WINPYDIR%\DLLs;%WINPYDIR%\Scripts;%PATH%;"
 set "PYTHON=%WINPYDIR%\python.exe "
 goto end
-) 
-IF EXIST python (
+)
 echo 未检测到集成环境，使用系统Python解释器
 set "PYTHON=python.exe "
-)ELSE (
-)
 :end


### PR DESCRIPTION
Win11，有安装系统Python解释器（输入python能进Python命令行），无论使用Powershell还是CMD，运行run_xx.bat都会报错“) was unexpected at this time.”。
检查后发现，environment.bat中的“IF EXIST python”并不能起到预想的效果，总是返回false。删掉这个判断，不要检测，无论如何都用python.exe尝试，最坏的结果是系统没有Python解释器，尝试失败，滚屏报错找不到python.exe，但至少不会有奇怪的报错。这样似乎是更好的选择（至少在我这里改完了就可以正常运行了）。